### PR TITLE
Add latest slides to Makefile for ODP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,9 @@ SLIDES := \
 	slides/error_8_security_group_not_associated.md \
 	slides/port_revisited.md \
 	slides/outputs_whats_my_floating_ip.md \
-	slides/error_9_cant_delete_stack.md
+	slides/error_9_cant_delete_stack.md \
+	slides/cloud_config.md \
+	slides/wait_condition.md
 
 slides.md: $(SLIDES)
 	cat $(SLIDES) > $@

--- a/slides/cloud_config.md
+++ b/slides/cloud_config.md
@@ -1,6 +1,6 @@
 ## `CloudConfig` resources
 
-### Much saner way to include Nova `user-data`
+**Much saner way to include Nova `user-data`**
 
 Install `git` and `emacs` immediately on system boot-up
 


### PR DESCRIPTION
- Missed the `Makefile` fix on the last PR, sorry.
- Didn't know `odpdown` choked on `###`.
